### PR TITLE
fwq.c: add the test result output

### DIFF
--- a/fwq.c
+++ b/fwq.c
@@ -342,6 +342,8 @@ int main(int argc, char **argv) {
   pthread_t *threads;
   cpu_set_t cpu_set;
 #endif
+  unsigned long long max_num = 1, max_time = 0, offset_num = 0;
+  double avg_time = 0;
 
   /* default output name prefix */
   sprintf(outname,"fwq");
@@ -516,6 +518,13 @@ int main(int argc, char **argv) {
     }
   }
 
+  max_num = numthreads * numsamples;
+  for(offset_num=0; offset_num<max_num; offset_num++ ) {
+    max_time += samples[offset_num];
+  }
+  avg_time = max_time/max_num;
+  printf("Total time for %d threads(%ld tasks/thread): %llu(ns)\nAverage time per thread per task:%.0f(ns)\n",
+         numthreads, numsamples, max_time, avg_time);
   free(samples);
 
 #ifdef _WITH_PTHREADS_


### PR DESCRIPTION
Add the test result for fwq benchmark test:
Take x86 WSL environment as an example,
result is as following:
./t_fwq -n 1000 -w 15 -t 8
...
Total time for 8 threads(1000 tasks/thread): 848893707(ns) Average time per thread per task:106111(ns)